### PR TITLE
Update example dci-queue commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The inventories are expecting `dci-queue` to be used with the
 following settings:
 
 ```ShellSession
-$ dci-queue add pool pool
-$ dci-queue add resource pool cluster1
+$ dci-queue add-pool pool
+$ dci-queue add-resource pool cluster1
 ```
 
 If you don't want to use `dci-queue`, just edit the the pipeline files


### PR DESCRIPTION
The README says to use add pool and add resource but the commands are actually add-pool and add-resource.