### PR TITLE
Move OCP pipeline to 4.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ EOF
 You can now customize the hooks, pipelines and inventories files for
 your own needs following [the DCI documentation](https://docs.distributed-ci.io/).
 
-By default 2 job descriptions (`ocp-4.12` and `workload`) and their
+By default 2 job descriptions (`ocp-4.17` and `workload`) and their
 associated hooks are present in the template.
 
 The inventories are expecting `dci-queue` to be used with the
@@ -48,7 +48,7 @@ to not use dynamic paths.
 For the full pipeline (OCP + workload):
 
 ```ShellSession
-$ dci-pipeline-schedule ocp-4.12 workload
+$ dci-pipeline-schedule ocp-4.17 workload
 ```
 
 For only the workload:
@@ -62,7 +62,7 @@ $ KUBECONFIG=$KUBECONFIG dci-pipeline-schedule workload
 For testing a PR with the full pipeline:
 
 ```ShellSession
-$ dci-pipeline-check https://github.com/dci-labs/<your company>-<lab>-config/pull/1 ocp-4.12 workload
+$ dci-pipeline-check https://github.com/dci-labs/<your company>-<lab>-config/pull/1 ocp-4.17 workload
 ```
 
 Or only with the workload:

--- a/pipelines/certification-pipeline.yml
+++ b/pipelines/certification-pipeline.yml
@@ -57,7 +57,7 @@
 
     # create cnf cert project
     cnf_to_certify:
-      - cnf_name: "my-test23.5 OCP4.12.49"
+      - cnf_name: "my-test23.5 OCP4.17.9"
         pyxis_product_lists:
           - "YYYYYYYYYYYYYYYYYYYYYYYY"
 

--- a/pipelines/ocp-4.17-pipeline.yml
+++ b/pipelines/ocp-4.17-pipeline.yml
@@ -8,7 +8,7 @@
   dci_credentials: ~/.config/dci-pipeline/dci_credentials.yml
   ansible_extravars:
     dci_cache_dir: ~/dci-cache-dir
-    dci_config_dirs: 
+    dci_config_dirs:
       - ~/config/ocp-install
     dci_gits_to_components:
       - ~/config

--- a/pipelines/ocp-4.17-pipeline.yml
+++ b/pipelines/ocp-4.17-pipeline.yml
@@ -8,13 +8,13 @@
   dci_credentials: ~/.config/dci-pipeline/dci_credentials.yml
   ansible_extravars:
     dci_cache_dir: ~/dci-cache-dir
-    dci_config_dirs:
+    dci_config_dirs: 
       - ~/config/ocp-install
     dci_gits_to_components:
       - ~/config
     dci_local_log_dir: ~/upload-errors
     dci_tags: []
-  topic: OCP-4.12
+  topic: OCP-4.17
   components:
     - ocp
   outputs:


### PR DESCRIPTION
We use [dci_config_dir](https://github.com/redhat-cip/dci-openshift-app-agent/blob/master/dci-openshift-app-agent.yml#L211-L213) for the agent.