### PR TITLE
Add git hooks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          VERS=8.28.0
+          VERS=8.30.0
           curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v${VERS}/gitleaks_${VERS}_linux_x64.tar.gz \
           | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ Here is some documentation can could be helpful:
 - [DCI UI (Use RH SSO to login)](https://www.distributed-ci.io/jobs?limit=20&offset=0&sort=-created_at&where=state:active)
 - [DCI blog: Certification tests for OpenShift containers and operators: how to run with DCI](https://blog.distributed-ci.io/preflight-integration-in-dci.html)
 - Detailed documentation for some certification-related roles: [Preflight](https://github.com/redhatci/ansible-collection-redhatci-ocp/tree/main/roles/preflight), [Chart Verifier](https://github.com/redhatci/ansible-collection-redhatci-ocp/tree/main/roles/chart_verifier), [CNF](https://github.com/redhatci/ansible-collection-redhatci-ocp/tree/main/roles/openshift_cnf), [create_certification_projects](https://github.com/redhatci/ansible-collection-redhatci-ocp/tree/main/roles/create_certification_project).
+
+# Install git hooks
+
+Git hooks are provided to follow secure best practices to avoid leaking secrets on changes.
+To install them, run the following command from the repository:
+
+```ShellSession
+$ utils/install-hooks.sh
+```
+
+The pre-commit hook uses [gitleaks](https://github.com/zricethezav/gitleaks) to scan for secrets before committing.
+Make sure to have it installed on your system. Installation instructions can be found
+in the [gitleaks documentation](https://github.com/zricethezav/gitleaks#installation).

--- a/utils/hooks/commit-msg
+++ b/utils/hooks/commit-msg
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Get the commit message file
+COMMIT_MSG_FILE=$1
+
+# Check if gitleaks data file exists from pre-commit hook
+GL_DATA=".git/.gitleaks_data"
+
+if [[ -f "${GL_DATA}" ]]; then
+    # Append data to commit message
+    echo "" >> "${COMMIT_MSG_FILE}"
+    cat "${GL_DATA}" >> "${COMMIT_MSG_FILE}"
+
+    # Clean up temporary file
+    rm -f "${GL_DATA}"
+fi
+
+exit 0

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Exit when gitleaks is not installed
+if ! command -v gitleaks &> /dev/null; then
+    echo "Warning: gitleaks is not installed. Skipping..." >&2
+    sleep 10
+    exit 0
+fi
+
+# Run gitleaks to detect hardcoded secrets
+gitleaks git --pre-commit --redact --staged --no-banner --no-color --log-level error --verbose
+gl=$?
+
+# Exit if gitleaks found issues
+if [[ ${gl} -ne 0 ]]; then
+    exit ${gl}
+fi
+
+# Create a signature and a hash
+GL_VER=$(gitleaks version)
+TS=$(date --utc +%FT%T)
+GL_SIGN=$(echo -n "${GL_VER}|${TS}" | base64)
+GL_HASH=$(echo -n ${GL_SIGN}| sha1sum | awk '{print $1}')
+
+# Store the data in a temp file to be added as a git msg 
+cat > .git/.gitleaks_data <<EOF
+Gitleaks-Sign: ${GL_SIGN}
+Gitleaks-Hash: ${GL_HASH}
+EOF
+
+exit 0

--- a/utils/install-hooks.sh
+++ b/utils/install-hooks.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="${1:-.}"
+HOOKS_DIR="${TARGET_DIR}/.git/hooks"
+SOURCE_HOOKS_DIR="${SCRIPT_DIR}/hooks"
+
+usage() {
+    echo "Usage: ${0} [TARGET_DIRECTORY]"
+    echo ""
+    echo "Install git hooks to a git repository."
+    echo ""
+    echo "Arguments:"
+    echo "  TARGET_DIRECTORY  Path to the git repository (default: current directory)"
+    echo ""
+    echo "Examples:"
+    echo "  ${0}                    # Install hooks in current repository"
+    echo "  ${0} /path/to/repo      # Install hooks in specified repository"
+    exit 1
+}
+
+if [[ "${1}" = "-h" ]] ||
+   [[ "${1}" = "--help" ]]; then
+    usage
+fi
+
+# Check if target is a git repository
+if [[ ! -d "${TARGET_DIR}/.git" ]]; then
+    echo "Error: ${TARGET_DIR} is not a git repository" >&2
+    exit 1
+fi
+
+if [[ ! -d "${HOOKS_DIR}" ]]; then
+    echo "Error: Git hooks directory not found at ${HOOKS_DIR}" >&2
+    exit 1
+fi
+
+if [[ ! -d "${SOURCE_HOOKS_DIR}" ]]; then
+    echo "Error: Source hooks directory not found at ${SOURCE_HOOKS_DIR}"
+    exit 1
+fi
+
+echo "Installing git hooks to ${HOOKS_DIR}..."
+
+for hook in "${SOURCE_HOOKS_DIR}"/*; do
+    if [[ -f "${hook}" ]]; then
+        hook_name=$(basename "${hook}")
+        install -m 755 "${hook}" "${HOOKS_DIR}/${hook_name}"
+    fi
+done
+
+echo ""
+echo "Git hooks installed successfully!"


### PR DESCRIPTION
Include a pre-commit and commit-msg hook to run gitleaks on the commit. Also provide a script to install the hooks into any local respository easily.
Bump the version of gitleaks in the GitHub Action.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDEtMDNUMDA6MDY6MDU=
Gitleaks-Hash: 43356e641c2acf79549a3867e6adf98aeb9ae4cd