### PR TITLE
Improve gitleaks pre-commit hook and CI workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,6 +2,8 @@ name: gitleaks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   verify-signature:
     name: Verify Gitleaks Signature

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -2,9 +2,8 @@
 
 # Exit when gitleaks is not installed
 if ! command -v gitleaks &> /dev/null; then
-    echo "Warning: gitleaks is not installed. Skipping..." >&2
-    sleep 10
-    exit 0
+    echo "Error: gitleaks not found, please install it." >&2
+    exit 1
 fi
 
 # Run gitleaks to detect hardcoded secrets
@@ -19,8 +18,9 @@ fi
 # Create a signature and a hash
 GL_VER=$(gitleaks version)
 TS=$(date --utc +%FT%T)
-GL_SIGN=$(echo -n "${GL_VER}|${TS}" | base64)
-GL_HASH=$(echo -n ${GL_SIGN}| sha1sum | awk '{print $1}')
+TREE_HASH=$(git write-tree)
+GL_SIGN=$(echo -n "${GL_VER}|${TS}|${TREE_HASH}" | base64)
+GL_HASH=$(echo -n ${GL_SIGN}| sha256sum | awk '{print $1}')
 
 # Store the data in a temp file to be added as a git msg 
 cat > .git/.gitleaks_data <<EOF


### PR DESCRIPTION
Pre-commit hook now fails closed (exit 1) when gitleaks is not installed. If the pre-commit is installed is because it is required to run, and not having gitleaks defeats its purpose.
Pre-commit signature now uses SHA-256 with version|timestamp|tree_hash format, matching what the CI verify-signature job expects. Previously the hook used SHA-1 without the tree hash, so signatures never validated.
GitHub Actions workflow now declares explicit least-privilege permissions (contents: read) to restrict the GITHUB_TOKEN scope on same-repo PRs.

Assisted-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMTBUMjM6NDY6MDh8ZGFiY2UzNzkxMTNiZDA0ZTM4MzI3Yjk0ZGZmZGEwZjVkNDFiNTM4NA==
Gitleaks-Hash: d6e9c40ef22e77dc81894d42908391b162b7e2d0b78a8104f696f2778f7dfd4b