### PR TITLE
Convert inventory to YAML and secure examples with vault

### DIFF
--- a/inventories/pool/cluster1
+++ b/inventories/pool/cluster1
@@ -1,233 +1,308 @@
-# -*- ini -*-
+---
 
-[all:vars]
+all:
+  vars:
+    ###########################################################################
+    # Sensitive credentials                                                   #
+    #                                                                         #
+    # Replace placeholder values with Ansible Vault encrypted strings using   #
+    # dci-vault (https://docs.distributed-ci.io/python-dciclient/#dci-vault)  #
+    #                                                                         #
+    #   dci-vault encrypt_string 'my_password' --name vault_ipmi_password     #
+    #                                                                         #
+    # Then replace the placeholder below with the output, e.g.:               #
+    #                                                                         #
+    #   vault_ipmi_password: !vault |                                         #
+    #     $ANSIBLE_VAULT;1.2;AES256                                           #
+    #     61626364656667686970...                                             #
+    ###########################################################################
+    vault_ipmi_user: CHANGEME
+    vault_ipmi_password: CHANGEME
+    vault_pullsecret: CHANGEME
+    # vault_proxy_user: CHANGEME
+    # vault_proxy_password: CHANGEME
 
-###############################################################################
-# Required configuration variables for IPI on Baremetal Installations         #
-###############################################################################
+    ###########################################################################
+    # Required configuration variables for IPI on Baremetal Installations     #
+    ###########################################################################
 
-# The provisioning NIC (NIC1) used on all baremetal nodes
-prov_nic=eno1
+    # The provisioning NIC (NIC1) used on all baremetal nodes
+    prov_nic: eno1
 
-# The public NIC (NIC2) used on all baremetal nodes
-pub_nic=eno2
+    # The public NIC (NIC2) used on all baremetal nodes
+    pub_nic: eno2
 
-# (Optional) Set the provisioning bridge name. Default value is 'provisioning'.
-#provisioning_bridge=provisioning
+    # (Optional) Set the provisioning bridge name. Default value is 'provisioning'.
+    # provisioning_bridge: provisioning
 
-# (Optional) Set the baremetal bridge name. Default value is 'baremetal'.
-#baremetal_bridge=baremetal
+    # (Optional) Set the baremetal bridge name. Default value is 'baremetal'.
+    # baremetal_bridge: baremetal
 
-# (Optional) Activation-key for proper setup of subscription-manager, empty value skips registration
-#activation_key=""
+    # (Optional) Activation-key for proper setup of subscription-manager, empty value skips registration
+    # activation_key: ""
 
-# (Optional) Activation-key org_id for proper setup of subscription-manager, empty value skips registration
-#org_id=""
+    # (Optional) Activation-key org_id for proper setup of subscription-manager, empty value skips registration
+    # org_id: ""
 
-# The directory used to store the cluster configuration files (install-config.yaml, pull-secret.txt, metal3-config.yaml)
-dir="{{ ansible_user_dir }}/clusterconfigs"
+    # The directory used to store the cluster configuration files (install-config.yaml, pull-secret.txt, metal3-config.yaml)
+    dir: "{{ ansible_user_dir }}/clusterconfigs"
 
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.3', 'latest-4.4', explicit version i.e. 4.3.0-0.nightly-2019-12-09-035405
-version=""
+    # The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+    # Values accepted: 'latest-4.3', 'latest-4.4', explicit version i.e. 4.3.0-0.nightly-2019-12-09-035405
+    version: ""
 
-# (Optional) Fully disconnected installs require manually downloading the release.txt file and hosting the file
-# on a webserver accessible to the provision host. The release.txt file can be downloaded at
-# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/{{ version }}/release.txt (for DEV version)
-# https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/release.txt (for GA version)
-# Example of hosting the release.txt on your example.com webserver under the 'latest-4.3' version directory.
-# http://example.com:<port>/latest-4.3/release.txt
-# Provide the webserver URL as shown below if using fully disconnected
-#webserver_url=http://example.com:<port>
+    # (Optional) Fully disconnected installs require manually downloading the release.txt file and hosting the file
+    # on a webserver accessible to the provision host. The release.txt file can be downloaded at
+    # https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/{{ version }}/release.txt (for DEV version)
+    # https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ version }}/release.txt (for GA version)
+    # Example of hosting the release.txt on your example.com webserver under the 'latest-4.3' version directory.
+    # http://example.com:<port>/latest-4.3/release.txt
+    # Provide the webserver URL as shown below if using fully disconnected
+    # webserver_url: "http://example.com:<port>"
 
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message.
-build=""
+    # Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+    # Empty value results in playbook failing with error message.
+    build: ""
 
-# (Optional) Provisioning IP Network and dhcp range (default value)
-# If defined, make sure to update 'prov_ip' with a valid IP outside of your 'prov_dhcp_range' and update all other places like 'no_proxy_list' 
-# prov_network=172.22.0.0/21
-# prov_dhcp_range="172.22.0.10,172.22.0.100"
+    # (Optional) Provisioning IP Network and dhcp range (default value)
+    # If defined, make sure to update 'prov_ip' with a valid IP outside of your 'prov_dhcp_range' and update all other places like 'no_proxy_list'
+    # prov_network: 172.22.0.0/21
+    # prov_dhcp_range: "172.22.0.10,172.22.0.100"
 
-# Provisioning IP address (default value)
-prov_ip=172.22.0.3
+    # Provisioning IP address (default value)
+    prov_ip: 172.22.0.3
 
-# (Optional) Enable playbook to pre-download RHCOS images prior to cluster deployment and use them as a local
-# cache. Default is false.
-#cache_enabled=True
+    # (Optional) Enable playbook to pre-download RHCOS images prior to cluster deployment and use them as a local
+    # cache. Default is false.
+    # cache_enabled: true
 
-# (Optional) The port exposed on the caching webserver. Default is port 8080.
-#webserver_caching_port=8080
+    # (Optional) The port exposed on the caching webserver. Default is port 8080.
+    # webserver_caching_port: 8080
 
-# (Optional) Enable IPv6 addressing instead of IPv4 addressing on both provisioning and baremetal network
-#ipv6_enabled=True
+    # (Optional) Enable IPv6 addressing instead of IPv4 addressing on both provisioning and baremetal network
+    # ipv6_enabled: true
 
-# (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on provisioning network
-# Default is false.
-#ipv4_provisioning=True
+    # (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on provisioning network
+    # Default is false.
+    # ipv4_provisioning: true
 
-# (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on baremetal network
-#ipv4_baremetal=True
+    # (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on baremetal network
+    # ipv4_baremetal: true
 
-# (Optional) When ipv6_enabled is set to True, but want dual-stack for baremetal network
-# Only one of ipv4_baremetal and dualstack_baremetal can be true
-#dualstack_baremetal=False
+    # (Optional) When ipv6_enabled is set to True, but want dual-stack for baremetal network
+    # Only one of ipv4_baremetal and dualstack_baremetal can be true
+    # dualstack_baremetal: false
 
-# (Optional) A list of clock servers to be used in chrony by the masters and workers
-#clock_servers=["pool.ntp.org","clock.redhat.com"]
+    # (Optional) A list of clock servers to be used in chrony by the masters and workers
+    # clock_servers:
+    #   - pool.ntp.org
+    #   - clock.redhat.com
 
-# (Optional) Provide HTTP proxy settings
-#http_proxy=http://USERNAME:PASSWORD@proxy.example.com:8080
+    # (Optional) Provide HTTP proxy settings
+    # http_proxy: "http://{{ vault_proxy_user }}:{{ vault_proxy_password }}@proxy.example.com:8080"
 
-# (Optional) Provide HTTPS proxy settings
-#https_proxy=https://USERNAME:PASSWORD@proxy.example.com:8080
+    # (Optional) Provide HTTPS proxy settings
+    # https_proxy: "https://{{ vault_proxy_user }}:{{ vault_proxy_password }}@proxy.example.com:8080"
 
-# (Optional) comma-separated list of hosts, IP Addresses, or IP ranges in CIDR format
-# excluded from proxying
-# NOTE: OpenShift does not accept '*' as a wildcard attached to a domain suffix
-# i.e. *.example.com
-# Use '.' as the wildcard for a domain suffix as shown in the example below.
-# i.e. .example.com
-#no_proxy_list="172.22.0.0/24,.example.com"
+    # (Optional) comma-separated list of hosts, IP Addresses, or IP ranges in CIDR format
+    # excluded from proxying
+    # NOTE: OpenShift does not accept '*' as a wildcard attached to a domain suffix
+    # i.e. *.example.com
+    # Use '.' as the wildcard for a domain suffix as shown in the example below.
+    # i.e. .example.com
+    # no_proxy_list: "172.22.0.0/24,.example.com"
 
-# The default installer timeouts for the bootstrap and install processes may be too short for some baremetal
-# deployments. The variables below can be used to extend those timeouts.
+    # The default installer timeouts for the bootstrap and install processes may be too short for some baremetal
+    # deployments. The variables below can be used to extend those timeouts.
 
-# (Optional) Increase bootstrap process timeout by N iterations.
-#increase_bootstrap_timeout=2
+    # (Optional) Increase bootstrap process timeout by N iterations.
+    # increase_bootstrap_timeout: 2
 
-# (Optional) Increase install process timeout by N iterations.
-#increase_install_timeout=2
+    # (Optional) Increase install process timeout by N iterations.
+    # increase_install_timeout: 2
 
-# (Optional) Disable RedFish inspection to intelligently choose between IPMI or RedFish protocol.
-# By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
-#redfish_inspection=false
+    # (Optional) Disable RedFish inspection to intelligently choose between IPMI or RedFish protocol.
+    # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
+    # redfish_inspection: false
 
-# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the
-# control plane and worker nodes.
-# If defined, playbook will look for files in control plane and worker subdirectories.
-# Otherwise, it will look in {{ role_path }}/files/customize_filesystem (default)
-# For more information on modifying node filesystems visit: https://bit.ly/36tD30f
-#customize_node_filesystems="/path/to/customized/filesystems"
+    # (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the
+    # control plane and worker nodes.
+    # If defined, playbook will look for files in control plane and worker subdirectories.
+    # Otherwise, it will look in {{ role_path }}/files/customize_filesystem (default)
+    # For more information on modifying node filesystems visit: https://bit.ly/36tD30f
+    # customize_node_filesystems: "/path/to/customized/filesystems"
 
-# (Optional) Modify the path to add external manifests to the deployed nodes.
-# There are two folders manifests/ and openshift/
-# If defined, the playbook will copy manifests from the user provided directory.
-# Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
-#customize_extramanifests_path="/path/to/extra/manifests"
-#customize_extramanifestsopenshift_path="/path/to/extra/openshift"
+    # (Optional) Modify the path to add external manifests to the deployed nodes.
+    # There are two folders manifests/ and openshift/
+    # If defined, the playbook will copy manifests from the user provided directory.
+    # Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
+    # customize_extramanifests_path: "/path/to/extra/manifests"
+    # customize_extramanifestsopenshift_path: "/path/to/extra/openshift"
 
-######################################
-# Vars regarding install-config.yaml #
-######################################
+    ######################################
+    # Vars regarding install-config.yaml #
+    ######################################
 
-# Base domain, i.e. example.com
-domain=""
-# Name of the cluster, i.e. openshift
-cluster="cluster1"
-# The public CIDR address, i.e. 10.1.1.0/21 (for IPv4 only and Dual-Stack deploys)
-extcidrnet=""
-# The public CIDR address for IPv6 only and Dual-Stack deploys
-extcidrnet6=""
-# An IP reserved on the baremetal network.
-# Deprecated in OpenShift 4.5 (https://github.com/openshift/installer/pull/3304)
-#dnsvip=""
-# An IP reserved on the baremetal network for the API endpoint.
-# (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
-#apivip=""
-# An IP reserved on the baremetal network for the Ingress endpoint.
-# (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
-#ingressvip=""
-# The master hosts provisioning nic
-# (Optional) If not set, the prov_nic will be used
-#masters_prov_nic=""
-# Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
-# Uncomment below for OpenShiftSDN
-#network_type="OpenShiftSDN"
-# (Optional) A URL to override the default operating system image for the bootstrap node.
-# The URL must contain a sha256 hash of the image.
-# See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
-#   Example https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...
-#bootstraposimage=""
-# (Optional) A URL to override the default operating system image for the cluster nodes.
-# The URL must contain a sha256 hash of the image.
-# See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
-# Example https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8...
-#clusterosimage=""
-# A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
-pullsecret=""
+    # Base domain, i.e. example.com
+    domain: ""
+    # Name of the cluster, i.e. openshift
+    cluster: cluster1
+    # The public CIDR address, i.e. 10.1.1.0/21 (for IPv4 only and Dual-Stack deploys)
+    extcidrnet: ""
+    # The public CIDR address for IPv6 only and Dual-Stack deploys
+    extcidrnet6: ""
+    # An IP reserved on the baremetal network.
+    # Deprecated in OpenShift 4.5 (https://github.com/openshift/installer/pull/3304)
+    # dnsvip: ""
+    # An IP reserved on the baremetal network for the API endpoint.
+    # (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
+    # apivip: ""
+    # An IP reserved on the baremetal network for the Ingress endpoint.
+    # (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
+    # ingressvip: ""
+    # The master hosts provisioning nic
+    # (Optional) If not set, the prov_nic will be used
+    # masters_prov_nic: ""
+    # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
+    # Uncomment below for OpenShiftSDN
+    # network_type: OpenShiftSDN
+    # (Optional) A URL to override the default operating system image for the bootstrap node.
+    # The URL must contain a sha256 hash of the image.
+    # See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
+    #   Example https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...
+    # bootstraposimage: ""
+    # (Optional) A URL to override the default operating system image for the cluster nodes.
+    # The URL must contain a sha256 hash of the image.
+    # See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
+    # Example https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8...
+    # clusterosimage: ""
 
-# (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC, ensure to set to True.
-# Default value is False.
-#disable_bmc_certificate_verification=True
+    # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
+    # Encrypt with: dci-vault encrypt_string '<pullsecret_json>' --name vault_pullsecret
+    pullsecret: "{{ vault_pullsecret }}"
 
-# (Optional) Enable RedFish VirtualMedia/iDRAC VirtualMedia
-#enable_virtualmedia=True
+    # (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC,
+    # ensure to set to true. Default value is false.
+    # Consider importing the BMC CA certificate into the trust store instead of disabling verification.
+    # disable_bmc_certificate_verification: true
 
-# (Required when enable_virtualmedia is set to True) Set an available IP address from the baremetal net for these two variables
-#provisioningHostIP=<baremetal_net_IP1>
-#bootstrapProvisioningIP=<baremetal_net_IP2>
+    # (Optional) Enable RedFish VirtualMedia/iDRAC VirtualMedia
+    # enable_virtualmedia: true
 
-# (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI.
-#bootmode=legacy
+    # (Required when enable_virtualmedia is set to True) Set an available IP address from the baremetal net for these two variables
+    # provisioningHostIP: <baremetal_net_IP1>
+    # bootstrapProvisioningIP: <baremetal_net_IP2>
 
-# Master nodes
-# The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
-# See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
-# ipmi_port is optional for each host. 623 is the common default used if omitted
-# poweroff is optional. True or ommited (by default) indicates the playbook will power off the node before deploying OCP
-#  otherwise set it to false
-# (Optional) irmc_address and imrc_port can be set in addition to ipmi_* if the BMC is Fujitsu irmc
-# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
-# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
-# Root Device Hint values are case sensitive. If incorrect case given, entry omitted from install-config.yaml
-# root_device_hint="deviceName"
-# root_device_hint_value="/dev/sda"
+    # (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI.
+    # bootmode: legacy
 
-[masters]
-master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default poweroff=true
-master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default poweroff=true
-master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 ipmi_port=623 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default poweroff=true
+  children:
+    masters:
+      # Master nodes
+      # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
+      # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
+      # ipmi_port is optional for each host. 623 is the common default used if omitted
+      # poweroff is optional. True or omitted (by default) indicates the playbook will power off the node before deploying OCP
+      #   otherwise set it to false
+      # (Optional) irmc_address and irmc_port can be set in addition to ipmi_* if the BMC is Fujitsu irmc
+      # (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+      # root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
+      # Root Device Hint values are case sensitive. If incorrect case given, entry omitted from install-config.yaml
+      # root_device_hint: deviceName
+      # root_device_hint_value: /dev/sda
+      hosts:
+        master-0:
+          name: master-0
+          role: master
+          ipmi_user: "{{ vault_ipmi_user }}"
+          ipmi_password: "{{ vault_ipmi_password }}"
+          ipmi_address: 192.168.1.1
+          ipmi_port: 623
+          provision_mac: "ec:f4:bb:da:0c:58"
+          hardware_profile: default
+          poweroff: true
+        master-1:
+          name: master-1
+          role: master
+          ipmi_user: "{{ vault_ipmi_user }}"
+          ipmi_password: "{{ vault_ipmi_password }}"
+          ipmi_address: 192.168.1.2
+          ipmi_port: 623
+          provision_mac: "ec:f4:bb:da:32:88"
+          hardware_profile: default
+          poweroff: true
+        master-2:
+          name: master-2
+          role: master
+          ipmi_user: "{{ vault_ipmi_user }}"
+          ipmi_password: "{{ vault_ipmi_password }}"
+          ipmi_address: 192.168.1.3
+          ipmi_port: 623
+          provision_mac: "ec:f4:bb:da:0d:98"
+          hardware_profile: default
+          poweroff: true
 
-# Worker nodes
-[workers]
-worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown poweroff=true
-worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 ipmi_port=623 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown poweroff=true
+    workers:
+      # Worker nodes
+      hosts:
+        worker-0:
+          name: worker-0
+          role: worker
+          ipmi_user: "{{ vault_ipmi_user }}"
+          ipmi_password: "{{ vault_ipmi_password }}"
+          ipmi_address: 192.168.1.4
+          ipmi_port: 623
+          provision_mac: "ec:f4:bb:da:0c:18"
+          hardware_profile: unknown
+          poweroff: true
+        worker-1:
+          name: worker-1
+          role: worker
+          ipmi_user: "{{ vault_ipmi_user }}"
+          ipmi_password: "{{ vault_ipmi_password }}"
+          ipmi_address: 192.168.1.5
+          ipmi_port: 623
+          provision_mac: "ec:f4:bb:da:32:28"
+          hardware_profile: unknown
+          poweroff: true
 
-# Provision Host
-[provisioner]
-provisioner.example.com
+    provisioner:
+      # Provision Host
+      hosts:
+        provisioner.example.com: {}
 
-# Registry Host
-#   Define a host here to create or use a local copy of the installation registry
-#   Used for disconnected installation
-# [registry_host]
-# registry.example.com
+    # Registry Host
+    #   Define a host here to create or use a local copy of the installation registry
+    #   Used for disconnected installation
+    # registry_host:
+    #   hosts:
+    #     registry.example.com:
+    #   vars:
+    #     # The following cert_* variables are needed to create the certificates
+    #     #   when creating a disconnected registry. They are not needed to use
+    #     #   an existing disconnected registry.
+    #     # cert_country: US
+    #     # cert_state: MyState
+    #     # cert_locality: MyCity
+    #     # cert_organization: MyCompany
+    #     # cert_organizational_unit: MyDepartment
+    #     #
+    #     # The port exposed on the disconnected registry host can be changed from
+    #     # the default 5000 to something else by changing the following variable.
+    #     # registry_port: 5000
+    #     #
+    #     # The directory the mirrored registry files are written to can be modified from the default /opt/registry by changing the following variable.
+    #     # registry_dir: /opt/registry
+    #     #
+    #     # The following two variables must be set to use an existing disconnected registry.
+    #     #
+    #     # Specify a file that contains extra auth tokens to include in the
+    #     #   pull-secret if they are not already there.
+    #     # disconnected_registry_auths_file: /path/to/registry-auths.json
+    #     #
+    #     # Specify a file that contains the addition trust bundle and image
+    #     #   content sources for the local registry. The contents of this file
+    #     #   will be appended to the install-config.yml file.
+    #     # disconnected_registry_mirrors_file: /path/to/install-config-appends.json
 
-# [registry_host:vars]
-# The following cert_* variables are needed to create the certificates
-#   when creating a disconnected registry. They are not needed to use
-#   an existing disconnected registry.
-# cert_country=US  # two letters country
-# cert_state=MyState
-# cert_locality=MyCity
-# cert_organization=MyCompany
-# cert_organizational_unit=MyDepartment
-
-# The port exposed on the disconnected registry host can be changed from
-# the default 5000 to something else by changing the following variable.
-# registry_port=5000
-
-# The directory the mirrored registry files are written to can be modified from teh default /opt/registry by changing the following variable.
-# registry_dir="/opt/registry"
-
-# The following two variables must be set to use an existing disconnected registry.
-#
-# Specify a file that contains extra auth tokens to include in the
-#   pull-secret if they are not already there.
-# disconnected_registry_auths_file=/path/to/registry-auths.json
-
-# Specify a file that contains the addition trust bundle and image
-#   content sources for the local registry. The contents of this file
-#   will be appended to the install-config.yml file.
-# disconnected_registry_mirrors_file=/path/to/install-config-appends.json
+...

--- a/pipelines/ansible.cfg
+++ b/pipelines/ansible.cfg
@@ -5,7 +5,7 @@ action_plugins      = /usr/share/dci/action_plugins/
 filter_plugins      = /usr/share/dci/filter_plugins/
 callback_whitelist  = profile_tasks, dci, junit
 retry_files_enabled = False
-host_key_checking   = False
+host_key_checking   = True   # Set this to False in trusted CI environments
 roles_path          = /usr/share/dci-openshift-agent/roles/:/usr/share/dci/roles/:usr/share/dci/roles/:~/dci-cache-dir/baremetal_deploy_repo/ansible-ipi-install/roles/
 log_path            = ansible.log
 


### PR DESCRIPTION
Replace the INI inventory with YAML format to properly support Ansible Vault encrypted variables. Credentials (IPMI, pull secret, proxy) now reference vault_* variables with CHANGEME placeholders and instructions for encrypting them using dci-vault.
Previously, the template shipped plaintext placeholder credentials that partners would replace with real values and commit in cleartext. The new pattern encourages encrypting secrets before committing. Set host_key_checking to True in ansible.cfg. It was previously disabled globally, exposing all SSH connections (including the non-ephemeral provisioner host) to potential MITM attacks on the management network.

Assisted-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMTFUMDA6MTI6MDV8NGRjYmFjMmVkNGYzZTRiZTc0ZWM3OGE5YzI5ZGU0YTNhMmU3NGY0OQ==
Gitleaks-Hash: 5d7dda49285c7fc90841ba0acad2409d0522d4a4996348ba29170c281a50ca13